### PR TITLE
Fix #12

### DIFF
--- a/app/src/Widget/Actions.jsx
+++ b/app/src/Widget/Actions.jsx
@@ -59,6 +59,7 @@ class DraggableResponsiveDialogUntranslated extends React.PureComponent {
               /* Be fullsreen on `sm` sreens */
               fullScreen={ fullScreen }
               aria-labelledby={ `draggable-dialog-title-${id}-${open}` }
+              style={{ height: window.innerHeight }}
             >
               <DialogTitle style={{ cursor: 'move' }} id={ `draggable-dialog-title-${id}-${open}` }>
                 <Title { ...restProps } t={ t } />


### PR DESCRIPTION
reference: https://chanind.github.io/javascript/2019/09/28/avoid-100vh-on-mobile-web.html