### PR TITLE
#35 update alert badge for small screens

### DIFF
--- a/app/src/Dashboard.jsx
+++ b/app/src/Dashboard.jsx
@@ -16,8 +16,8 @@ import IconButton from '@material-ui/core/IconButton';
 import Container from '@material-ui/core/Container';
 import Link from '@material-ui/core/Link';
 import MenuIcon from '@material-ui/icons/Menu';
-/*
 import Badge from '@material-ui/core/Badge';
+/*
 import NotificationsIcon from '@material-ui/icons/Notifications';
 */
 
@@ -151,6 +151,7 @@ const Dashboard = (props) => {
   const handleDrawerClose = () => {
     setOpen(false);
   };
+  const shouldShowUpdateBadge = useMediaQuery(createMuiTheme().breakpoints.down('md')) && props.newServiceWorkerDetected;
 
   return (
     <AppThemeProvider type={ theme } >
@@ -165,7 +166,9 @@ const Dashboard = (props) => {
               onClick={handleDrawerOpen}
               className={clsx(classes.menuButton, open && classes.menuButtonHidden)}
             >
-              <MenuIcon />
+              <Badge badgeContent={1} color={"secondary"} invisible={!shouldShowUpdateBadge}>
+                <MenuIcon />
+              </Badge>
             </IconButton>
             <Typography component="h1" variant="h6" color="inherit" noWrap className={classes.title}>
               { t("Covid Data") }{' '}


### PR DESCRIPTION
For https://github.com/emibcn/covid/issues/35

Badge is visible for small screens (smaller than md = 960px) when there is an update available. It's a red 1 symbol like this:

![image](https://user-images.githubusercontent.com/57956571/97048181-edcc2980-1571-11eb-8c2a-77fa1225d993.png)
