### PR TITLE
Tests: Add and fix tests for `Backend/Base/*`:

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -65,16 +65,19 @@ jobs:
         rounded-precision: 2
         filename: "app/coverage/clover.xml"
 
-    - name: Test debug - show branch name and origin branch name
+    - name: Extract branch name
       shell: bash
       run: |
-        echo "PULL HEAD REF: ${{ github.head_ref }}"
-        echo "GITHUB REF: ${GITHUB_REF}"
-
-    - name: Extract branch name
-      if: ${{ github.event_name != 'pull_request' }}
-      shell: bash
-      run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
+        TMP_PULL_HEAD_REF="${{ github.head_ref }}"
+        TMP_GITHUB_REF="${GITHUB_REF#refs/heads/}"
+        EXPORT_VALUE=""
+        if [ "${TMP_PULL_HEAD_REF}" != "" ]
+        then
+            EXPORT_VALUE="${TMP_PULL_HEAD_REF}"
+        else
+            EXPORT_VALUE="${TMP_GITHUB_REF}"
+        fi
+        echo "##[set-output name=branch;]$(echo ${EXPORT_VALUE})"
       id: extract_branch
 
     - uses: actions/checkout@v2
@@ -84,7 +87,7 @@ jobs:
 
     # Use the output from the `coverage` step
     - name: Generate the badge SVG image
-      if: ${{ github.event_name != 'pull_request' }}
+      if: ${{ github.event_name == 'pull_request' || github.ref == 'refs/heads/master' }}
       uses: emibcn/badge-action@v1
       id: badge
       with:
@@ -103,7 +106,7 @@ jobs:
         path: test-coverage.svg
 
     - name: Commit badge
-      if: ${{ github.event_name != 'pull_request' }}
+      if: ${{ github.event_name == 'pull_request' || github.ref == 'refs/heads/master' }}
       env:
         BRANCH: ${{ steps.extract_branch.outputs.branch }}
         FILE: 'test-coverage.svg'
@@ -117,7 +120,7 @@ jobs:
         # Will give error if badge did not changed
         git commit -m "Add/Update badge" || true
     - name: Push badge commit
-      if: ${{ github.event_name != 'pull_request' }}
+      if: ${{ github.event_name == 'pull_request' || github.ref == 'refs/heads/master' }}
       uses: ad-m/github-push-action@master
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -65,11 +65,11 @@ jobs:
         rounded-precision: 2
         filename: "app/coverage/clover.xml"
 
-    - name: Test debug: show branch name and origin branch name
+    - name: Test debug - show branch name and origin branch name
       shell: bash
       run: |
         echo "PULL HEAD REF: ${{ github.head_ref }}"
-        echo "GITHUB REF: ${GITHUB_REF#refs/heads/}"
+        echo "GITHUB REF: ${GITHUB_REF}"
 
     - name: Extract branch name
       if: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -65,6 +65,14 @@ jobs:
         rounded-precision: 2
         filename: "app/coverage/clover.xml"
 
+    - name: test debug: show branch name and origin branch name
+      shell: bash
+      env:
+        PULL_FROM: ${{ github.head_ref }}
+      run: |
+        echo "PULL HEAD REF: ${{ github.head_ref }}"
+        echo "GITHUB REF: ${GITHUB_REF#refs/heads/}"
+
     - name: Extract branch name
       if: ${{ github.event_name != 'pull_request' }}
       shell: bash

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -65,10 +65,8 @@ jobs:
         rounded-precision: 2
         filename: "app/coverage/clover.xml"
 
-    - name: test debug: show branch name and origin branch name
+    - name: Test debug: show branch name and origin branch name
       shell: bash
-      env:
-        PULL_FROM: ${{ github.head_ref }}
       run: |
         echo "PULL HEAD REF: ${{ github.head_ref }}"
         echo "GITHUB REF: ${GITHUB_REF#refs/heads/}"

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -81,7 +81,7 @@ jobs:
       id: extract_branch
 
     - uses: actions/checkout@v2
-      if: ${{ github.event_name != 'pull_request' }}
+      if: ${{ github.event_name == 'pull_request' || github.ref == 'refs/heads/master' }}
       with:
         ref: badges
 

--- a/app/src/Backend/Base/Common.test.js
+++ b/app/src/Backend/Base/Common.test.js
@@ -1,0 +1,136 @@
+import { delay, MockFetch, AbortError } from '../../testHelpers';
+
+import Common from './Common';
+
+// Common is suposed to be extended
+class TestCommon extends Common {
+  constructor({onUpdate, ...rest}={}) {
+    super(rest);
+    this.onUpdate = onUpdate || (() => {});
+  }
+  subscribe = jest.fn( (url) => {
+    return fetch( url, { signal: this.controller.signal })
+      .then( this.handleFetchErrors )
+      .then( response => response.json() )
+      .then( this.onUpdate )
+      .catch( this.catchFetchErrors )
+  });
+}
+
+let mockedFetch = new MockFetch();
+beforeAll(() => {
+  mockedFetch.mock();
+});
+
+afterAll(() => {
+  mockedFetch.unmock();
+});
+
+test('Common calls onUpdate', async () => {
+  const url = 'test1';
+  const options = {
+    onUpdate: jest.fn(),
+    onError: jest.fn(),
+  };
+  const testCommon = new TestCommon(options);
+  await testCommon.subscribe(url);
+
+  expect(options.onUpdate).toHaveBeenCalledTimes(1);
+});
+
+test('Common calls onError when error is thrown', async () => {
+  const url = 'test1';
+  const options = {
+    onUpdate: jest.fn(),
+    onError: jest.fn(),
+  };
+  const testCommon = new TestCommon(options);
+  const fetchThrowErrorOld = mockedFetch.options.throwError;
+  mockedFetch.options.throwError = new Error("Testing network/server errors");
+  await testCommon.subscribe(url);
+
+  expect(options.onError).toHaveBeenCalledTimes(1);
+  mockedFetch.options.throwError = fetchThrowErrorOld;
+});
+
+test('Common does not calls onUpdate nor onError when thrown error is an AbortError', async () => {
+  const url = 'test1';
+  const options = {
+    onUpdate: jest.fn(),
+    onError: jest.fn(),
+  };
+  const testCommon = new TestCommon(options);
+  const fetchThrowErrorOld = mockedFetch.options.throwError;
+  mockedFetch.options.throwError = new AbortError("Testing abort errors");
+  await testCommon.subscribe(url);
+
+  expect(options.onUpdate).toHaveBeenCalledTimes(0);
+  expect(options.onError).toHaveBeenCalledTimes(0);
+  mockedFetch.options.throwError = fetchThrowErrorOld;
+});
+
+test('Common calls onError when response is errorish', async () => {
+  const url = 'test1';
+  const options = {
+    onUpdate: jest.fn(),
+    onError: jest.fn(),
+  };
+  const testCommon = new TestCommon(options);
+  // Test server error
+  const fetchResponseOptionsOld = mockedFetch.options.responseOptions;
+  mockedFetch.options.responseOptions = () => ({
+    status: 401,
+    statusText: "Testing unauthorized request",
+    ok: false,
+  });
+  await testCommon.subscribe(url);
+
+  expect(options.onError).toHaveBeenCalledTimes(1);
+  mockedFetch.options.responseOptions = fetchResponseOptionsOld;
+});
+
+test('Common uses noop default values for onUpdate and onError', async () => {
+  const url = 'test1';
+  const testCommon = new TestCommon();
+
+  // Test for onUpdate
+  const onUpdateOriginal = testCommon.onUpdate;
+  testCommon.onUpdate = jest.fn(onUpdateOriginal);
+  await testCommon.subscribe(url);
+
+  expect(testCommon.onUpdate).toHaveBeenCalledTimes(1);
+
+  // Test for onError
+  const onErrorOriginal = testCommon.onError;
+  testCommon.onError = jest.fn(onErrorOriginal);
+  const fetchThrowErrorOld = mockedFetch.options.throwError;
+  mockedFetch.options.throwError = new Error("Testing network/server errors");
+  await testCommon.subscribe(url);
+
+  expect(testCommon.onError).toHaveBeenCalledTimes(1);
+  mockedFetch.options.throwError = fetchThrowErrorOld;
+});
+
+test('Common aborts a connection correctly', async () => {
+  const url = 'test1';
+  const testCommon = new TestCommon();
+
+  // Mock controller's abort method to count its calls
+  const abortOriginal = testCommon.controller.abort;
+  const abortMocked = jest.fn(abortOriginal);
+  testCommon.controller.abort = abortMocked;
+  const promise = testCommon.subscribe(url);
+  await delay(1);
+
+  testCommon.abort();
+
+  // Ensure promise is not left in background
+  await promise;
+
+  // Controller's abort has been called once
+  expect(abortMocked).toHaveBeenCalledTimes(1);
+
+  // Controller has been substituted, so abort function
+  // must not be the same as before
+  expect(abortMocked).not.toBe(testCommon.controller.abort);
+});

--- a/app/src/Backend/Base/GHPages.test.js
+++ b/app/src/Backend/Base/GHPages.test.js
@@ -1,0 +1,156 @@
+import {
+  delay,
+  catchConsoleLog,
+  catchConsoleWarn,
+  catchConsoleError
+} from '../../testHelpers';
+
+import GHPages from './GHPages';
+
+/*
+  TODO:
+   - Test `scheduleNextUpdate` with recursive
+   - Test `scheduleNextUpdate` with no need to update (`mockCacheSuccessValue = false`)
+   - Test `millisToNextUpdate` with an extra day timelapse (`officialUpdateTime` on today, but earlier than now)
+*/
+const mockDelay = delay;
+let mockCacheSuccess = true;
+let mockCacheSuccessValue = true;
+let mockCacheErrorValue = new Error("Test cache checkIfNeedUpdate error");
+jest.mock("./Cache", () => {
+  return {
+    __esModule: true,
+    default: {
+      invalidate: jest.fn( async (url) => {
+        await mockDelay(10);
+      }),
+      checkIfNeedUpdate: jest.fn( async (url, onSuccess, onError) => {
+        await mockDelay(10);
+        if (mockCacheSuccess) {
+          await onSuccess(mockCacheSuccessValue);
+        }
+        else {
+          onError(mockCacheErrorValue);
+        }
+      }),
+    },
+  }
+});
+
+class TestGHPages extends GHPages {
+  indexUrl = 'testIndex';
+
+  // Invalidate all URLs, except index
+  invalidateAll = jest.fn(async () => {
+    await delay(10);
+  });
+}
+
+test('GHPages correctly checks for updates', async () => {
+  const testGHPages = new TestGHPages();
+  const onSuccess = jest.fn();
+  const onError = jest.fn();
+
+  // Test success with update needed
+  const {output: outputSuccess} = await catchConsoleLog( async () => {
+    await testGHPages.checkUpdate(onSuccess, onError);
+  });
+  expect(onSuccess).toHaveBeenCalledTimes(1);
+  expect(onError).toHaveBeenCalledTimes(0);
+  expect(onSuccess).toHaveBeenCalledWith(mockCacheSuccessValue);
+  expect(outputSuccess[0].includes("update needed")).toBe(true);
+
+  // Test error
+  mockCacheSuccess = false;
+  const {output: outputError} = await catchConsoleError( async () => {
+    await testGHPages.checkUpdate(onSuccess, onError);
+  });
+  expect(onSuccess).toHaveBeenCalledTimes(1);
+  expect(onError).toHaveBeenCalledTimes(1);
+  expect(outputError[1].includes("Test cache checkIfNeedUpdate error")).toBe(true);
+  mockCacheSuccess = true;
+});
+
+test('GHPages correctly warns about the need to overload `invalidateAll`', async () => {
+  const testGHPages = new GHPages();
+  const {output} = await catchConsoleWarn( async () => {
+    await testGHPages.invalidateAll();
+  });
+  expect(output[0].includes("abstract function")).toBe(true);
+});
+
+test('GHPages correctly updates all own URLs', async () => {
+  const testGHPages = new TestGHPages();
+  const callback = jest.fn();
+  const {output} = await catchConsoleLog( async () => {
+    await testGHPages.updateAll(callback);
+  });
+  expect(output[0].includes("Invalidate index")).toBe(true);
+  expect(testGHPages.invalidateAll).toHaveBeenCalledTimes(1);
+  expect(callback).toHaveBeenCalledTimes(1);
+});
+
+test('GHPages correctly updates all own URLs, if needed', async () => {
+  const testGHPages = new TestGHPages();
+  const callback = jest.fn();
+
+  // Test no need to update
+  mockCacheSuccessValue = false;
+  const {output} = await catchConsoleLog( async () => {
+    await testGHPages.updateIfNeeded(callback);
+  });
+  expect(output[0].includes("update needed: false")).toBe(true);
+  expect(testGHPages.invalidateAll).toHaveBeenCalledTimes(0);
+  expect(callback).toHaveBeenCalledTimes(1);
+  expect(callback).toHaveBeenCalledWith(false);
+  mockCacheSuccessValue = true;
+
+  // Test need to update
+  const {output: output2} = await catchConsoleLog( async () => {
+    await testGHPages.updateIfNeeded(callback);
+  });
+  expect(output2[0].includes("update needed: true")).toBe(true);
+  expect(testGHPages.invalidateAll).toHaveBeenCalledTimes(1);
+  expect(callback).toHaveBeenCalledTimes(2);
+  expect(callback).toHaveBeenCalledWith(true);
+});
+
+test('GHPages correctly schedules next update loop', async () => {
+  const testGHPages = new TestGHPages();
+  const nowPlus2Minutes = new Date();
+  nowPlus2Minutes.setMinutes(nowPlus2Minutes.getMinutes() + 2);
+  testGHPages.officialUpdateTime = [
+    nowPlus2Minutes.getHours(),
+    nowPlus2Minutes.getMinutes()
+  ];
+  // Prepend '0' to minutes if it's smaller than 10
+  const expectedTimeString = `${testGHPages.officialUpdateTime[0]}:${testGHPages.officialUpdateTime[1] < 10 ? '0' : ''}${testGHPages.officialUpdateTime[1]}`;
+
+  // First try: update on mocked schedule
+  const {output} = await catchConsoleLog( async () => {
+    await testGHPages.scheduleNextUpdate();
+  });
+  expect(output[0].includes("Next update on")).toBe(true);
+  expect(output[0].includes(expectedTimeString)).toBe(true);
+  expect(testGHPages.invalidateAll).toHaveBeenCalledTimes(0);
+
+  // Second try: update on `nextMillis` millisecond
+  const nextMillis = 20;
+  const {output: output2} = await catchConsoleLog( async () => {
+    await testGHPages.scheduleNextUpdate(nextMillis);
+  });
+  expect(output2[0].includes("Next update on")).toBe(true);
+  expect(testGHPages.invalidateAll).toHaveBeenCalledTimes(0);
+
+  const checkUpdateOld = testGHPages.checkUpdate;
+  testGHPages.checkUpdate = jest.fn( async (...args) => {
+    // Silence output
+    await catchConsoleLog( async () => {
+      await checkUpdateOld.bind(testGHPages)(...args);
+    });
+  });
+
+  await delay(nextMillis*2);
+
+  expect(testGHPages.invalidateAll).toHaveBeenCalledTimes(1);
+});

--- a/app/src/ErrorCatcher.test.jsx
+++ b/app/src/ErrorCatcher.test.jsx
@@ -17,7 +17,7 @@ test('renders correctly its children', () => {
   expect(child).toBeInTheDocument();
 });
 
-test('renders error when some `render` throws an error and reloads page when the button is clicked', () => {
+test('renders error when some `render` throws an error and reloads page when the button is clicked', async () => {
   const text = "I'm a child";
   const error = "I'm an error";
   const BuggyChild = (props) => {
@@ -25,8 +25,8 @@ test('renders error when some `render` throws an error and reloads page when the
   };
 
   let errorCatcher;
-  act(() => {
-    const {output, fn} = catchConsoleError( () => {
+  await act(async () => {
+    const {output, fn} = await catchConsoleError( () => {
       errorCatcher = render(
         <ErrorCatcher>
           {/* Buggy's siblings are not shown, either */}


### PR DESCRIPTION
- Backend/Base/Cache:
  - Tests: abstract and move fetch mocking code and AbortError definition to `testHelpers` and use it
  - Code: Use Backend/Base/Common as a base class of FetchCacheElement
- Backend/Base/Common:
  - Tests: Add tests
  - Code:
    - Fix bug in handleFetchErrors (throw Error instead of return it)
    - Abstract a bit to allow using it as base class in FetchCacheElement
- Backend/Base/GHPages:
  - Tests: Add tests
  - Code:
    - Move conditional log logic to `log` function
    - Return some async functions return value and await to some function calls to allow `await` on it and simplify tests
- testHelpers: Transform message console log catchers to wrap async functions (works well for non-async functions, too)
- ErrorCatcher: Use message console log catchers as `async` functions