### PR TITLE
Simplify backends usage

### DIFF
--- a/app/src/Backend/Base/ContextCreator.jsx
+++ b/app/src/Backend/Base/ContextCreator.jsx
@@ -3,8 +3,8 @@ import React, { createContext, useContext } from 'react';
 const ContextCreator = (Handler, defaultName) => {
   const Context = createContext();
   
-  const Provider = ({children}) => (
-    <Context.Provider value={Handler}>
+  const Provider = ({children, value=Handler}) => (
+    <Context.Provider value={value}>
       {children}
     </Context.Provider>
   );

--- a/app/src/Backend/Bcn/handler.js
+++ b/app/src/Backend/Bcn/handler.js
@@ -95,6 +95,9 @@ class BcnDataHandler extends GHPages {
     return this.indexData.find( ({code}) => code === dataset );
   }
 
+  // Return filtered index data values
+  filter = (fn) => this.indexData.filter( fn );
+
   // Active URLs: those which will be invalidated on update
   active = [];
 

--- a/app/src/Backend/Bcn/withHandlers.js
+++ b/app/src/Backend/Bcn/withHandlers.js
@@ -6,10 +6,7 @@ const withIndex = (WrappedComponent, name="index") =>
   withHandlerGenerator(
     withHandler,
     () => ({}),
-    (props, Handler, setIndex) => {
-      const handler = new Handler();
-      return handler.index( setIndex );
-    },
+    (props, Handler, setIndex) => Handler.index( setIndex ),
     name,
     WrappedComponent,
   );
@@ -18,12 +15,8 @@ const withIndex = (WrappedComponent, name="index") =>
 const withData = (WrappedComponent, name="bcnData") => {
   const WrapperComponent = withHandlerGenerator(
     withHandler,
-    ({dataset, bcnIndex}) =>
-      ({dataset, bcnIndex}),
-    ({dataset, bcnIndex}, Handler, setData) => {
-      const handler = new Handler(bcnIndex);
-      return handler.data( dataset, setData )
-    },
+    ({dataset}) => ({dataset}),
+    ({dataset}, Handler, setData) => Handler.data( dataset, setData ),
     name,
     WrappedComponent,
   );

--- a/app/src/Backend/Charts/handler.js
+++ b/app/src/Backend/Charts/handler.js
@@ -114,6 +114,40 @@ class ChartDataHandler extends GHPages {
     return this.findChild(initialLink, url);
   }
 
+  // Used to fix region when changing main options.
+  // TODO: Find a better way. ID by breadcrumb?
+  findRegion = (division, population, region) => {
+    const initialNode = this.findInitialNode(division, population);
+    const found = this.findChild(initialNode, region);
+
+    if ( !found ) {
+      // Try to find in the other valid initialNodes (same division)
+      const nodes = this.indexData.filter( (node) =>
+        division === node.territori &&
+        population !== node.poblacio
+      );
+      for (const node of nodes ) {
+        // Look for region in the other initialNode
+        const f1 = this.findChild(node, region);
+        // If found, find in our initialNode for a region with the same name
+        const f2 = f1 && this.findChild(
+          initialNode,
+          f1.name,
+          (node, name) => node.name === name);
+        // If found, use it
+        if (f2) {
+          return f2;
+        }
+      }
+
+      // Not found in valid initialNodes: default to actual initialNode's root
+      return initialNode;
+    }
+
+    // Found!
+    return found;
+  }
+
   // Fetch JSON data and subscribe to updates
   data = (division, population, url, callback) => {
 

--- a/app/src/Backend/Charts/withHandlers.js
+++ b/app/src/Backend/Charts/withHandlers.js
@@ -6,10 +6,7 @@ const withIndex = (WrappedComponent, name="index") =>
   withHandlerGenerator(
     withHandler,
     () => ({}),
-    (props, Handler, setIndex) => {
-      const handler = new Handler();
-      return handler.index( setIndex );
-    },
+    (props, Handler, setIndex) => Handler.index( setIndex ),
     name,
     WrappedComponent,
   );
@@ -18,12 +15,10 @@ const withIndex = (WrappedComponent, name="index") =>
 const withData = (WrappedComponent, name="chartData") => {
   const WrapperComponent = withHandlerGenerator(
     withHandler,
-    ({chartDivision, chartPopulation, chartRegion, chartsIndex}) =>
-      ({chartDivision, chartPopulation, chartRegion, chartsIndex}),
-    ({chartDivision, chartPopulation, chartRegion, chartsIndex}, Handler, setData) => {
-      const handler = new Handler(chartsIndex);
-      return handler.data( chartDivision, chartPopulation, chartRegion, setData )
-    },
+    ({chartDivision, chartPopulation, chartRegion}) =>
+      ({chartDivision, chartPopulation, chartRegion}),
+    ({chartDivision, chartPopulation, chartRegion}, Handler, setData) =>
+      Handler.data( chartDivision, chartPopulation, chartRegion, setData ),
     name,
     WrappedComponent,
   );

--- a/app/src/Backend/IndexesHandler.jsx
+++ b/app/src/Backend/IndexesHandler.jsx
@@ -8,6 +8,8 @@ import { withHandler as withMapsDataHandler } from '../Backend/Maps/context';
 import { withHandler as withChartsDataHandler } from '../Backend/Charts/context';
 import { withHandler as withBcnDataHandler } from '../Backend/Bcn/context';
 
+import Provider from './Provider';
+
 // Initially downloads all backends indexes
 // - Shows <Loading/> while data is downloading
 // - Handles data updates:
@@ -32,10 +34,11 @@ class IndexesHandler extends React.Component {
     super(props);
 
     // Create initial handled backends array
-    this.backends = ['mapsDataHandler', 'chartsDataHandler', 'bcnDataHandler']
-      .map( backendProp => ({
-        initializer: props[backendProp],
-        state: backendProp,
+    this.backends = ['maps', 'charts', 'bcn']
+      .map( name => ({
+        name,
+        initializer: props[`${name}DataHandler`],
+        state: `${name}DataHandler`,
         unsubscribe: () => {},
       }));
 
@@ -176,11 +179,22 @@ class IndexesHandler extends React.Component {
     const indexes = this.backends
       .map( ({state}) => state)
       .map( state => this.state[state]);
+    const provided = this.backends
+      .reduce(
+        (acc, {name, handler}) => ({
+          ...acc,
+          [name]: handler,
+        }),
+        {});
 
     // Show <Loading/> while some index has not yet been loaded
     return indexes.some( index => !index )
       ? <Loading />
-      : this.props.children;
+      : (
+        <Provider { ...provided }>
+          { this.props.children }
+        </Provider>
+      );
   }
 }
 

--- a/app/src/Backend/Maps/withHandlers.js
+++ b/app/src/Backend/Maps/withHandlers.js
@@ -6,10 +6,7 @@ const withIndex = (WrappedComponent, name="days") =>
   withHandlerGenerator(
     withHandler,
     () => ({}),
-    (props, Handler, setIndex) => {
-      const handler = new Handler();
-      return handler.index( setIndex );
-    },
+    (props, Handler, setIndex) => Handler.index( setIndex ),
     name,
     WrappedComponent,
   );
@@ -20,8 +17,7 @@ const withData = (WrappedComponent, name="mapData") => {
     withHandler,
     ({mapKind, mapValue}) => ({mapKind, mapValue}),
     ({mapKind, mapValue}, Handler, setData) => {
-      const handler = new Handler();
-      return handler.data( mapKind, mapValue, (data) => {
+      return Handler.data( mapKind, mapValue, (data) => {
         // Optimization: Transform received data to use Map()
         // instead of Object() in days values
         const newData = {

--- a/app/src/Backend/Provider.jsx
+++ b/app/src/Backend/Provider.jsx
@@ -4,11 +4,11 @@ import BcnProvider from './Bcn/context';
 import MapsProvider from './Maps/context';
 import ChartsProvider from './Charts/context';
 
-const BackendProvider = ({children}) => {
+const BackendProvider = ({children, bcn, maps, charts}) => {
   return (
-    <BcnProvider>
-      <MapsProvider>
-        <ChartsProvider>
+    <BcnProvider value={bcn}>
+      <MapsProvider value={maps}>
+        <ChartsProvider value={charts}>
           {children}
         </ChartsProvider>
       </MapsProvider>

--- a/app/src/Widget/List.jsx
+++ b/app/src/Widget/List.jsx
@@ -18,13 +18,13 @@ const S4 = () => (((1+Math.random())*0x10000)|0).toString(16).substring(1);
 const guidGenerator = () => "a-"+S4()+S4()+"-"+S4()+"-"+S4()+"-"+S4()+"-"+S4()+S4()+S4();
 
 // Renders widgets list
-// - Manages days list (using backend) and current selected Date with a Slider
+// - Manages days list (using backend) and currently selected Date with a Slider
 // - Receives managed plugins params from props (with storage context providers and consumer)
 // - Receives Widgets param modification events and calls parents param event
 //   handlers callbacks with processed data:
-//   - Add (not from widgets but from MenuAddWidget)
-//   - Edit
-//   - Remove
+//   - Add (from MenuAddWidget)
+//   - Edit (from widgets)
+//   - Remove (from widgets)
 //   - Reorder (from SortableWidgetContainer)
 // - Blindly (with `payload`) handles different types of widgets depending on passed/saved
 //   params from URL and localStorage

--- a/app/src/Widget/Widgets/Bcn/Edit.jsx
+++ b/app/src/Widget/Widgets/Bcn/Edit.jsx
@@ -3,48 +3,30 @@ import PropTypes from 'prop-types';
 
 import { translate } from 'react-translate'
 
-//import Divider from '@material-ui/core/Divider';
-
-import {FormDecorators/*, Selector*/} from '../Common';
+import {FormDecorators} from '../Common';
 import DatasetSelector from './EditDataset';
 
 /*
-   Renders the edit form for the Map widget
+   Renders the edit form for the BCN widget
 */
-class Edit extends React.PureComponent {
-
-  onChangeDataset = (value) => this.props.onChangeDataset(value);
-
-  render() {
-    const {
-      dataset,
-      bcnIndex,
-      t
-    } = this.props;
-
-    return (
-      <div style={{ textAlign: 'left' }}>
-        <FormDecorators
-          id={ 'sections-tree' }
-          label={ t("Select the dataset") }
-          fixTree
-        >
-          <DatasetSelector
-            bcnIndex={ bcnIndex }
-            value={ dataset }
-            onChange={ this.onChangeDataset }
-          />
-        </FormDecorators>
-      </div>
-    )
-  }
-}
+const Edit = ({ dataset, t, onChangeDataset }) => (
+  <div style={{ textAlign: 'left' }}>
+    <FormDecorators
+      id={ 'sections-tree' }
+      label={ t("Select the dataset") }
+      fixTree
+    >
+      <DatasetSelector
+        value={ dataset }
+        onChange={ onChangeDataset }
+      />
+    </FormDecorators>
+  </div>
+)
 
 Edit.propTypes = {
   dataset: PropTypes.string.isRequired,
-  bcnIndex: PropTypes.array.isRequired,
   onChangeDataset: PropTypes.func.isRequired,
-  onChangeSection: PropTypes.func.isRequired,
 };
 
 export default translate('Widget/Bcn/Edit')(Edit);

--- a/app/src/Widget/Widgets/Bcn/EditDataset.jsx
+++ b/app/src/Widget/Widgets/Bcn/EditDataset.jsx
@@ -17,19 +17,25 @@ const styles = {
   },
 };
 
-const Tree = (props) => {
-  const {node} = props;
-  return (
-    <TreeItem key={node.code} nodeId={`${!('values' in node) ? 'DISABLED-' : ''}${node.code}`} label={node.title} >
-      {Array.isArray(node.sections) ? node.sections.map( node => <Tree node={node} />) : null}
-    </TreeItem>
-  )
-};
+const Tree = ({node}) => (
+  <TreeItem
+    key={node.code}
+    nodeId={`${!('values' in node) ? 'DISABLED-' : ''}${node.code}`}
+    label={node.title}
+  >
+    {
+      Array.isArray(node.sections)
+        ? node.sections.map( (node, key) => <Tree {...{node, key}} />)
+        : null
+    }
+  </TreeItem>
+)
 
 class RecursiveTreeView extends React.Component {
 
   state = {
     breadcrumb: [],
+    value: '',
   }
 
   onNodeSelect = (event, value, ...rest) => {
@@ -39,20 +45,21 @@ class RecursiveTreeView extends React.Component {
     }
   }
 
-  componentWillMount = () => {
-    const { value, bcnIndex, bcnDataHandler } = this.props;
-    const bcnData = new bcnDataHandler(bcnIndex);
+  constructor(props) {
+    super(props);
 
-    this.setState({
+    const { value, bcnDataHandler } = props;
+
+    this.state = {
       value,
-      breadcrumb: bcnData
+      breadcrumb: bcnDataHandler
         .findBreadcrumb(null, value)
         .map(node => `${!('values' in node) ? 'DISABLED-' : ''}${node.code}`),
-    });
+    };
   }
 
-  render = (props) => {
-    const { classes, bcnIndex, ...restProps } = this.props;
+  render = () => {
+    const { classes, bcnDataHandler, ...restProps } = this.props;
     const { breadcrumb, value } = this.state;
 
     return (
@@ -65,7 +72,7 @@ class RecursiveTreeView extends React.Component {
         onNodeSelect={ this.onNodeSelect }
         { ...restProps }
       >
-        { bcnIndex
+        { bcnDataHandler
             .filter( section => ['graph','chart'].includes(section.type) )
             .map( section => <Tree key={section.code} node={section} />) }
       </TreeView>

--- a/app/src/Widget/Widgets/Chart/Edit.jsx
+++ b/app/src/Widget/Widgets/Chart/Edit.jsx
@@ -67,8 +67,8 @@ const Selector = (props) => {
           id: id,
         }}
       >
-        { options.map( option => (
-          <option key={ `v_${option.value}` } value={ option.value }>{ option.label }</option>
+        { options.map( ({value, label}) => (
+          <option key={ `v_${value}` } value={ value }>{ label }</option>
         )) }
       </Select>
     </FormDecorators>

--- a/app/src/Widget/Widgets/Chart/EditRegion.jsx
+++ b/app/src/Widget/Widgets/Chart/EditRegion.jsx
@@ -20,25 +20,43 @@ const useStyles = makeStyles({
 
 const RecursiveTreeView = (props) => {
   const classes = useStyles();
-  const { chartsIndex, division, population, value, onChange, chartsDataHandler,...restProps } = props;
+  const {
+    chartsIndex,
+    division,
+    population,
+    value,
+    onChange,
+    chartsDataHandler,
+    ...restProps
+  } = props;
 
   const onNodeSelect = (event, value) => onChange(Number(value));
 
-  const renderTree = (nodes) => (
-    <TreeItem key={nodes.url} nodeId={`${nodes.url}`} label={nodes.name}>
-      {Array.isArray(nodes.children) ? nodes.children.map((node) => renderTree(node)) : null}
+  const renderTree = ({url, name, children}) => (
+    <TreeItem
+      key={url}
+      nodeId={`${url}`}
+      label={name}
+    >
+      {
+        Array.isArray(children)
+          ? children.map( renderTree )
+          : null
+      }
     </TreeItem>
   );
 
   const {initialNode, found} = React.useMemo(
     () => {
-      const chartData = new chartsDataHandler(chartsIndex);
-      const initialNode = chartData.findInitialNode(division, population);
-      const found = chartData.findBreadcrumb(initialNode, value).map(link => `${link.url}`);
+      const initialNode = chartsDataHandler
+        .findInitialNode(division, population);
+      const found = chartsDataHandler
+        .findBreadcrumb(initialNode, value)
+        .map(({url}) => `${url}`);
 
       return {initialNode, found}
     },
-    [division, population, value, chartsIndex, chartsDataHandler]
+    [division, population, value, chartsDataHandler]
   );
 
   return (

--- a/app/src/Widget/Widgets/Map/Edit.jsx
+++ b/app/src/Widget/Widgets/Map/Edit.jsx
@@ -43,8 +43,8 @@ const Selector = (props) => {
             id: id,
           }}
         >
-          { options.map( option => (
-            <option key={ `v_${option.value}` } value={ option.value }>{ option.label }</option>
+          { options.map( ({value, label}) => (
+            <option key={ `v_${value}` } value={ value }>{ label }</option>
           )) }
         </Select>
         { help ? (


### PR DESCRIPTION
Backend ContextCreator:
- Allow modifying context value using `<Provider value={} />`, which defaults to previous behavior: the backend Handler
- `withIndex` and `withData` now expects `Handler` to be an instance instead of the class constructor

BackendProvider: Allow providing custom values for each backend
IndexesHandler: Re-Provide all backend contexts as handler instance (once indexes are loaded) instead of their handler class constructor

Move to backend handlers functions using it's index:
- Backend: Charts: Handler: Move to handler `findRegion` from `Widget/Widgets/Chart/Widget.jsx`
- Backend: BCN: Handler: add `filter` to get filtered index data (will be used in `Widget/Widgets/Bcn/EditDataset.jsx`)

Widgets/List: Fix some comments

Widgets: BCN: Simplify using simplified backends HOCs:
- Stop using `bcnIndex` and `withIndex`
- Transform `Edit` to functional component
- Don't instantiate the provided handler from context

Widgets: Charts: Simplify using simplified backends HOCs:
- Stop using `chartsIndex` and `withIndex`
- Remove `findRegion` (now in backend handler)
- Use format similar to BCN widget

Widgets: Map: Edit: Use similar format than Charts
