### PR TITLE
Move Service Worker updating mechanism to a component HOC:

### DIFF
--- a/app/src/App.jsx
+++ b/app/src/App.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import { HashRouter as Router } from 'react-router-dom';
 
 import Storage from 'react-simple-storage';
@@ -68,38 +67,14 @@ class App extends React.Component {
     // Fix bad browser encoding HASH
     fixLocationHash();
 
-    this.registration = false; // For App updates
     const language = getDefaultLanguage(available);
     this.state = {
       initializing: true,              // For Storage
-      newServiceWorkerDetected: false, // For App updates
       language,
       theme: false,                    // Use defined by user in browser
       tutorialSeen: false,
     };
   }
-
-  componentDidMount() {
-    // Receive message from index.js when a new service worker has been detected
-    document.addEventListener('onNewServiceWorker', this.handleNewServiceWorker);
-  }
-
-  componentWillUnmount() {
-    // Remove event listener
-    document.removeEventListener('onNewServiceWorker', this.handleNewServiceWorker);
-  }
-
-  // When new serviceWorker is accepted, save the registration object
-  // and change own state, which will be passed to Dashboard to let the user upgrade
-  handleNewServiceWorker = (event) => {
-    this.registration = event.detail.registration;
-    this.setState({
-      newServiceWorkerDetected: true,
-    });
-  }
-
-  // Once the user accepts to update, call index.js callback
-  handleLoadNewServiceWorkerAccept = () => this.props.onLoadNewServiceWorkerAccept(this.registration);
 
   // Handle global configuration options
   handleLanguageChange = (language) => this.setState({ language });
@@ -107,7 +82,7 @@ class App extends React.Component {
   handleTutorialSeenChange = (tutorialSeen) => this.setState({ tutorialSeen });
 
   render() {
-    const { newServiceWorkerDetected, language, theme, tutorialSeen } = this.state;
+    const { language, theme, tutorialSeen } = this.state;
     const translations = available.find(_language => _language.key === language).value;
 
     return (
@@ -122,7 +97,7 @@ class App extends React.Component {
           <Storage
             parent={ this }
             prefix='App'
-            blacklist={ ['newServiceWorkerDetected','initializing'] }
+            blacklist={ ['initializing'] }
             onParentStateHydrated={ () => this.setState({ initializing: false }) }
           />
         </ErrorCatcher>
@@ -130,9 +105,6 @@ class App extends React.Component {
         {/* Shows the app, with ErrorBoundaries */}
         <ErrorCatcher origin='Dashboard'>
           <Dashboard
-            // Handle App update acceptance by user
-            newServiceWorkerDetected={ newServiceWorkerDetected }
-            onLoadNewServiceWorkerAccept={ this.handleLoadNewServiceWorkerAccept }
             // Use language and handle its change
             language={ language }
             onLanguageChange={ this.handleLanguageChange }
@@ -156,10 +128,6 @@ class App extends React.Component {
     );
   }
 }
-
-App.propTypes = {
-  onLoadNewServiceWorkerAccept: PropTypes.func.isRequired,
-};
 
 export default App;
 export {fixLocationHash, getDefaultLanguage}; // For tests

--- a/app/src/App.test.js
+++ b/app/src/App.test.js
@@ -11,9 +11,6 @@ jest.mock("./Dashboard", () => {
     __esModule: true,
     default: (props) => (
       <div data-testid="dashboard-mock">
-        <button data-testid="dashboard-mock-fn-accept-sw" onClick={ () => props.onLoadNewServiceWorkerAccept({ detail: { registration: "tested" } }) }>
-          Accept Service Worker
-        </button>
         <button data-testid="dashboard-mock-fn-language-change" onClick={ () => props.onLanguageChange("tested") }>
           Change Language
         </button>
@@ -24,9 +21,6 @@ jest.mock("./Dashboard", () => {
           Tutorial Seen
         </button>
 
-        <div data-testid="dashboard-mock-sw-detected">
-          { JSON.stringify(props.newServiceWorkerDetected) }
-        </div>
         <div data-testid="dashboard-mock-language">
           { JSON.stringify(props.language) }
         </div>
@@ -84,58 +78,16 @@ test('detects navigator language', () => {
   expect(getDefaultLanguage([{key: 'es-es'}])).toBe('es-es');
 });
 
-test('detects new service worker', async () => {
-  let app;
-  act( () => {
-    app = render(<App onLoadNewServiceWorkerAccept={()=>{}} />);
-  });
-  await act( async () => {
-    const event = new CustomEvent('onNewServiceWorker', { detail: { registration: true } });
-    fireEvent(document, event);
-
-    // Execute events block in current event loop
-    await delay(0);
-
-    const detectedNewSW = app.getByTestId("dashboard-mock-sw-detected");
-    expect(detectedNewSW).toHaveTextContent("true");
-  });
-});
-
 test('renders mocked dashboard', () => {
-  const app = render(<App onLoadNewServiceWorkerAccept={() => {}} />);
+  const app = render(<App />);
   const element = app.getByTestId("dashboard-mock");
   expect(element).toBeInTheDocument();
-});
-
-test('detects new service worker acceptance', async () => {
-  const onLoadNewServiceWorkerAccept = jest.fn();
-  let app;
-  act(() => {
-    app = render(<App onLoadNewServiceWorkerAccept={ onLoadNewServiceWorkerAccept } />);
-  });
-
-  await act( async () => {
-    // Fire event for new service worker detection
-    const event = new CustomEvent('onNewServiceWorker', { detail: { registration: "tested" } });
-    fireEvent(document, event);
-
-    // User accepts it
-    const button = app.getByTestId("dashboard-mock-fn-accept-sw");
-    expect(button).toBeInTheDocument();
-    fireEvent.click(button);
-
-    // Execute events block in current event loop
-    await delay(0);
-
-    expect(onLoadNewServiceWorkerAccept).toHaveBeenCalledTimes(1);
-    expect(onLoadNewServiceWorkerAccept).toHaveBeenCalledWith("tested");
-  });
 });
 
 test('detects user changed language', async () => {
   let app;
   act(() => {
-    app = render(<App onLoadNewServiceWorkerAccept={() => {}} />);
+    app = render(<App />);
   });
 
   await act( async () => {
@@ -155,7 +107,7 @@ test('detects user changed language', async () => {
 test('detects user changed theme', async () => {
   let app;
   act(() => {
-    app = render(<App onLoadNewServiceWorkerAccept={() => {}} />);
+    app = render(<App />);
   });
 
   await act( async () => {
@@ -175,7 +127,7 @@ test('detects user changed theme', async () => {
 test('detects user visited tutorial', async () => {
   let app;
   act(() => {
-    app = render(<App onLoadNewServiceWorkerAccept={() => {}} />);
+    app = render(<App />);
   });
 
   await act( async () => {

--- a/app/src/Dashboard.jsx
+++ b/app/src/Dashboard.jsx
@@ -22,6 +22,7 @@ import NotificationsIcon from '@material-ui/icons/Notifications';
 import Menu from './Menu';
 import ModalRouterWithRoutes from './ModalRouterWithRoutes';
 import AppThemeProvider from './AppThemeProvider';
+import withServiceWorkerUpdater from './withServiceWorkerUpdater';
 
 const Copyright = translate('Copyright')((props) => {
   const { t } = props;
@@ -143,5 +144,7 @@ const Dashboard = (props) => {
   );
 }
 
-export default translate('Widget')(Dashboard);
+export default translate('Widget')(
+  withServiceWorkerUpdater(Dashboard)
+);
 export {Copyright};

--- a/app/src/Dashboard.test.jsx
+++ b/app/src/Dashboard.test.jsx
@@ -50,6 +50,14 @@ jest.mock("./About", () => {
   };
 });
 
+// Mock ServiceWorker Updater HOC
+jest.mock("./withServiceWorkerUpdater", () => {
+  return {
+    __esModule: true,
+    default: (Wrapped) => Wrapped,
+  };
+});
+
 const objectCreator = ({initial, ...props}) => (
   <Router initialEntries={ initial }>
     <Dashboard { ...props } />

--- a/app/src/Menu.jsx
+++ b/app/src/Menu.jsx
@@ -161,10 +161,10 @@ const Menu = translate('Menu')((props) => {
 });
 
 Menu.propTypes = {
-  onLoadNewServiceWorkerAccept: PropTypes.func.isRequired,
   handleDrawerOpen: PropTypes.func.isRequired,
   handleDrawerClose: PropTypes.func.isRequired,
   open: PropTypes.bool.isRequired,
+  onLoadNewServiceWorkerAccept: PropTypes.func.isRequired,
   newServiceWorkerDetected: PropTypes.bool.isRequired,
 };
 

--- a/app/src/index.js
+++ b/app/src/index.js
@@ -3,37 +3,10 @@ import ReactDOM from 'react-dom';
 import App from './App';
 import * as serviceWorker from './serviceWorker';
 
-// Callback to call when user accepts loading new service worker
-// - Send message to SW to trigger the update
-// - Once updated, reload this window to load new assets
-const updateSW = (registration) => {
-  if ( registration.waiting ) {
-
-    // When the user asks to refresh the UI, we'll need to reload the window
-    let preventDevToolsReloadLoop;
-    navigator.serviceWorker.addEventListener('controllerchange', (event) => {
-
-      // Ensure refresh is only called once.
-      // This works around a bug in "force update on reload".
-      if (preventDevToolsReloadLoop) {
-        return;
-      }
-
-      preventDevToolsReloadLoop = true;
-      console.log('Controller loaded');
-      global.location.reload(true);
-    });
-
-    // Send a message to the new serviceWorker to activate itself
-    registration.waiting.postMessage('skipWaiting');
-  }
-};
-
-
 // Render the App
 ReactDOM.render(
   <React.StrictMode>
-    <App onLoadNewServiceWorkerAccept={ updateSW } />
+    <App />
   </React.StrictMode>,
   document.getElementById('root')
 );

--- a/app/src/sw-epilog.js
+++ b/app/src/sw-epilog.js
@@ -1,7 +1,7 @@
 // Add a listener to receive messages from clients
 self.addEventListener('message', function(event) {
   // Force SW upgrade (activation of new installed SW version)
-  if ( event.data === 'skipWaiting' ) {
+  if (event.data && event.data.type === 'SKIP_WAITING') {
     self.skipWaiting();
   }
 });

--- a/app/src/withServiceWorkerUpdater.jsx
+++ b/app/src/withServiceWorkerUpdater.jsx
@@ -1,0 +1,54 @@
+import React from 'react';
+
+// Callback to call when user accepts loading new service worker
+// - Send message to SW to trigger the update
+// - Once updated, reload this window to load new assets
+const updateSW = (registration) => {
+  if( registration.waiting ) {
+    // When the user asks to refresh the UI, we'll need to reload the window
+    let preventDevToolsReloadLoop;
+    navigator.serviceWorker.addEventListener('controllerchange', (event) => {
+
+      // Ensure refresh is only called once.
+      // This works around a bug in "force update on reload".
+      if (preventDevToolsReloadLoop) {
+        return;
+      }
+
+      preventDevToolsReloadLoop = true;
+      console.log('Controller loaded');
+      global.location.reload(true);
+    });
+
+    // Send a message to the new serviceWorker to activate itself
+    registration.waiting.postMessage({type: 'SKIP_WAITING'});
+  }
+};
+
+const withServiceWorkerUpdater = (WrappedComponent) =>
+  (props) => {
+    const [registration, setRegistration] = React.useState(false);
+    const [newServiceWorkerDetected, setNewServiceWorkerDetected] = React.useState(false);
+    const handleLoadNewServiceWorkerAccept = () => {
+      updateSW(registration);
+    }
+
+    // Add/remove event listeners for event thrown from `index.js`
+    React.useEffect(() => {
+      const handleNewServiceWorker = (event) => {
+        setRegistration(event.detail.registration);
+        setNewServiceWorkerDetected(true);
+      }
+
+      document.addEventListener('onNewServiceWorker', handleNewServiceWorker);
+      return () => document.removeEventListener('onNewServiceWorker', handleNewServiceWorker);
+    }, [setRegistration, setNewServiceWorkerDetected]);
+
+    return <WrappedComponent
+      {...props}
+      newServiceWorkerDetected={ newServiceWorkerDetected }
+      onLoadNewServiceWorkerAccept={ handleLoadNewServiceWorkerAccept }
+    />;
+  }
+
+export default withServiceWorkerUpdater;

--- a/app/src/withServiceWorkerUpdater.test.jsx
+++ b/app/src/withServiceWorkerUpdater.test.jsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { render, createEvent, fireEvent, act, waitFor, screen, cleanup } from '@testing-library/react';
+
+import { delay } from './testHelpers';
+
+import withServiceWorkerUpdater from './withServiceWorkerUpdater';
+
+const SWDetector = withServiceWorkerUpdater( (props) => (
+  <>
+    <button
+      data-testid="dashboard-mock-fn-accept-sw"
+      onClick={ () => {
+        props.onAccept("tested");
+        props.onLoadNewServiceWorkerAccept({ detail: { registration: "tested" } })
+      }}
+    >
+      Accept Service Worker
+    </button>
+    <div data-testid="dashboard-mock-sw-detected">
+      { JSON.stringify(props.newServiceWorkerDetected) }
+    </div>
+  </>
+));
+
+test('detects new service worker', async () => {
+  let app;
+  act( () => {
+    app = render(<SWDetector />);
+  });
+  await act( async () => {
+    const event = new CustomEvent('onNewServiceWorker', { detail: { registration: true } });
+    fireEvent(document, event);
+
+    // Execute events block in current event loop
+    await delay(0);
+
+    const detectedNewSW = app.getByTestId("dashboard-mock-sw-detected");
+    expect(detectedNewSW).toHaveTextContent("true");
+  });
+});
+
+test('detects new service worker acceptance', async () => {
+  const onLoadNewServiceWorkerAccept = jest.fn();
+  let app;
+  act(() => {
+    app = render(<SWDetector onAccept={ onLoadNewServiceWorkerAccept } />);
+  });
+
+  await act( async () => {
+    // Fire event for new service worker detection
+    const event = new CustomEvent('onNewServiceWorker', { detail: { registration: "tested" } });
+    fireEvent(document, event);
+
+    // User accepts it
+    const button = app.getByTestId("dashboard-mock-fn-accept-sw");
+    expect(button).toBeInTheDocument();
+    fireEvent.click(button);
+
+    // Execute events block in current event loop
+    await delay(100);
+
+    expect(onLoadNewServiceWorkerAccept).toHaveBeenCalledTimes(1);
+    expect(onLoadNewServiceWorkerAccept).toHaveBeenCalledWith("tested");
+  });
+});
+


### PR DESCRIPTION
- Change the message sent/received to match the new CRA standard in `sw-epilog.js`: `event.data === 'skipWaiting'` => `event.data && event.data.type === 'SKIP_WAITING'`
- Create a HOC which (code moved from `App.js`):
  - Adds/removes event listeners from document listening for `onNewServiceWorker` (emitted from `index.js`)
  - Stores the status of a new service worker detected
  - Passes the acceptation callback and the status to the Wrapped component via props
  - Move and fix tests
- Use the HOC directly where needed: in `Dashboard.jsx`