### PR TITLE
ErrorCatcher: Allow reloading the failing component and split logic from presentation

### DIFF
--- a/app/src/i18n/ca-es.lang.js
+++ b/app/src/i18n/ca-es.lang.js
@@ -33,6 +33,8 @@ const translations = {
     ...common,
     "Something went wrong :(": "Alguna cosa ha anat malament :(",
     "Try reloading the app to recover from it": "Intenta recarregar l'aplicació per a continuar",
+    "Try recreating this component to recover from the error": "Intenta recarregar aquest component per a continuar",
+    "Counter": "Recompte",
   },
 
   Menu: {

--- a/app/src/i18n/en-en.lang.js
+++ b/app/src/i18n/en-en.lang.js
@@ -33,6 +33,8 @@ const translations = {
     ...common,
     "Something went wrong :(": "Something went wrong :(",
     "Try reloading the app to recover from it": "Try reloading the app to recover from it",
+    "Try recreating this component to recover from the error": "Try recreating this component to recover from the error",
+    "Counter": "Counter",
   },
 
   Menu: {

--- a/app/src/i18n/es-es.lang.js
+++ b/app/src/i18n/es-es.lang.js
@@ -33,6 +33,8 @@ const translations = {
     ...common,
     "Something went wrong :(": "Algo ha ido mal :(",
     "Try reloading the app to recover from it": "Intenta recargar la aplicación para continuar",
+    "Try recreating this component to recover from the error": "Intenta recargar este component para continuar",
+    "Counter": "Recuento",
   },
 
   Menu: {

--- a/app/src/i18n/nb-no.lang.js
+++ b/app/src/i18n/nb-no.lang.js
@@ -33,6 +33,9 @@ const translations = {
     ...common,
     "Something went wrong :(": "Noe gikk galt :(",
     "Try reloading the app to recover from it": "Prøv å starte appen på nytt for å gjenopprette fra det",
+    // TODO:
+    "Try recreating this component to recover from the error": "Try recreating this component to recover from the error",
+    "Counter": "Counter",
   },
 
   Menu: {

--- a/app/src/i18n/pl-pl.lang.js
+++ b/app/src/i18n/pl-pl.lang.js
@@ -33,6 +33,9 @@ const translations = {
     ...common,
     "Something went wrong :(": "Coś poszło nie tak :(",
     "Try reloading the app to recover from it": "Spróbuj odświeżyć stronę by się z tego wydostać",
+    // TODO:
+    "Try recreating this component to recover from the error": "Try recreating this component to recover from the error",
+    "Counter": "Counter",
   },
 
   Menu: {


### PR DESCRIPTION
### ErrorCatcher
- Split logic from presentation
- Use new presentation as default, but allow overriding it
- Allow re-creating the component instead of reloading the entire page:
  - Count the errors detected on the wrapped component
  - Use different button text
  - Clean error on retry, so children needs to be rendered again
  - Add a hook `onRetry`, triggered after user clicks the retry button
  - Add translation texts

### Widget
 - Use `ErrorCatcher`'s `reloadOnRetry` on widgets wrappers to allow recovering from some network error

### Widgets/Maps/MapImage
 - Workaround for https://github.com/tanem/svg-injector/issues/692